### PR TITLE
Add trending controls for a better trending experience on small instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tags
 # Ignore IDE files
 .vscode/
 .idea/
+tags
 
 # Ignore postgres + redis + elasticsearch volume optionally created by docker-compose
 /postgres

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -6,10 +6,10 @@ class Trends::Statuses < Trends::Base
   BATCH_SIZE = 100
 
   self.default_options = {
-    threshold: ENV['TRENDS_STATUSES_THRESHOLD'].to_i || 5,
-    review_threshold: ENV['TRENDS_STATUSES_REVIEW_THRESHOLD'].to_i || 3,
-    score_halflife: (ENV['TRENDS_STATUSES_SCORE_HALFLIFE_HOURS'].to_i || 1).hour.freeze,
-    decay_threshold: ENV['TRENDS_STATUSES_DECAY_THRESHOLD'].to_i || 0.3,
+    threshold: ENV['TRENDS_STATUSES_THRESHOLD']&.to_i || 5,
+    review_threshold: ENV['TRENDS_STATUSES_REVIEW_THRESHOLD']&.to_i || 3,
+    score_halflife: (ENV['TRENDS_STATUSES_SCORE_HALFLIFE_HOURS']&.to_i || 1).hour.freeze,
+    decay_threshold: ENV['TRENDS_STATUSES_DECAY_THRESHOLD']&.to_i || 0.3,
   }
 
   class Query < Trends::Query

--- a/app/models/trends/statuses.rb
+++ b/app/models/trends/statuses.rb
@@ -6,10 +6,10 @@ class Trends::Statuses < Trends::Base
   BATCH_SIZE = 100
 
   self.default_options = {
-    threshold: 5,
-    review_threshold: 3,
-    score_halflife: 1.hour.freeze,
-    decay_threshold: 0.3,
+    threshold: ENV['TRENDS_STATUSES_THRESHOLD'].to_i || 5,
+    review_threshold: ENV['TRENDS_STATUSES_REVIEW_THRESHOLD'].to_i || 3,
+    score_halflife: (ENV['TRENDS_STATUSES_SCORE_HALFLIFE_HOURS'].to_i || 1).hour.freeze,
+    decay_threshold: ENV['TRENDS_STATUSES_DECAY_THRESHOLD'].to_i || 0.3,
   }
 
   class Query < Trends::Query

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -118,7 +118,7 @@ class PostStatusService < BaseService
   def postprocess_status!
     process_hashtags_service.call(@status)
     Trends.tags.register(@status)
-    Trends.register!(@status) if ENV['EASY_TREND']
+    Trends.register!(@status) if ENV['EASY_TREND']&.to_bool
     LinkCrawlWorker.perform_async(@status.id)
     DistributionWorker.perform_async(@status.id)
     ActivityPub::DistributionWorker.perform_async(@status.id)

--- a/app/services/post_status_service.rb
+++ b/app/services/post_status_service.rb
@@ -118,6 +118,7 @@ class PostStatusService < BaseService
   def postprocess_status!
     process_hashtags_service.call(@status)
     Trends.tags.register(@status)
+    Trends.register!(@status) if ENV['EASY_TREND']
     LinkCrawlWorker.perform_async(@status.id)
     DistributionWorker.perform_async(@status.id)
     ActivityPub::DistributionWorker.perform_async(@status.id)


### PR DESCRIPTION
This PR adds 5 ENV vars allowing admins to control how easy or hard it is for statuses to trend.

These vars control the default options for Status trends
`TRENDS_STATUSES_THRESHOLD` Int
`TRENDS_STATUSES_REVIEW_THRESHOLD` Int
`TRENDS_STATUSES_SCORE_HALFLIFE_HOURS` Int
`TRENDS_STATUSES_DECAY_THRESHOLD` Int

Mastodon only registers statuses for trends if the status has been reblogged. On smaller instances focused on just a few people, most users don't reblog anything. Statuses on these instances need to be registered for trends at create. You can do this by setting the `EASY_TREND` var to true
